### PR TITLE
Disable building of debug symbols.

### DIFF
--- a/daemontools.spec
+++ b/daemontools.spec
@@ -45,11 +45,11 @@ mkdir -p ${RPM_BUILD_ROOT}/usr/bin
 cp -p command/* ${RPM_BUILD_ROOT}/usr/bin
 cp -fp ${RPM_SOURCE_DIR}/svscanboot ${RPM_BUILD_ROOT}/usr/bin
 
-%if "%{_dist}" == ".el7"
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 23
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system
 cp -p ${RPM_SOURCE_DIR}/daemontools.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system
 %endif
-%if "%{_dist}" == ".el6"
+%if 0%{?el6}
 mkdir -p ${RPM_BUILD_ROOT}/etc/init
 cp -p ${RPM_SOURCE_DIR}/daemontools.conf ${RPM_BUILD_ROOT}/etc/init
 %endif
@@ -62,33 +62,33 @@ rm -rf ${RPM_BUILD_ROOT}
 %post
 [ -d /service ] || mkdir /service
 
-%if "%{_dist}" == ".el6"
+%if 0%{?el6}
 initctl reload-configuration
 %endif
-%if "%{_dist}" == ".el5" || "%{_dist}" == ".el4"
+%if 0%{?el5} || 0%{?el4}
 echo 'SV:123456:respawn:/usr/bin/svscanboot' >> /etc/inittab
 %endif
 
 
 %preun
-%if "%{_dist}" == ".el7"
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 23
 systemctl stop daemontools.service
 systemctl disable daemontools.service 2> /dev/null
 %endif
-%if "%{_dist}" == ".el6"
+%if 0%{?el6}
 initctl stop daemontools > /dev/null 2>&1 ||:
 %endif
-%if "%{_dist}" == ".el5" || "%{_dist}" == ".el4"
+%if 0%{?el5} || 0%{?el4}
 pkill svscan ||:
 pkill svscanboot ||:
 %endif
 
 
 %postun
-%if "%{_dist}" == ".el6"
+%if 0%{?el6}
 initctl reload-configuration
 %endif
-%if "%{_dist}" == ".el5" || "%{_dist}" == ".el4"
+%if 0%{?el5} || 0%{?el4}
 sed -i '/svscanboot/d' /etc/inittab
 %endif
 
@@ -113,10 +113,10 @@ rmdir /service 2> /dev/null ||:
 %attr(0755,root,root) /usr/bin/svstat
 %attr(0755,root,root) /usr/bin/tai64n
 %attr(0755,root,root) /usr/bin/tai64nlocal
-%if "%{_dist}" == ".el7"
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 23
 %attr(0644,root,root) /usr/lib/systemd/system/daemontools.service
 %endif
-%if "%{_dist}" == ".el6"
+%if 0%{?el6}
 %attr(0644,root,root) /etc/init/daemontools.conf
 %endif
 

--- a/daemontools.spec
+++ b/daemontools.spec
@@ -2,6 +2,7 @@
 %define _ver	0.76
 %define _dist	%(sh /usr/lib/rpm/redhat/dist.sh)
 %define _rel	1%{?_dist}
+%global debug_package %{nil}
 
 
 Name:		%{_name}


### PR DESCRIPTION
I am not sure anyone will ever need symbols for daemontools and it
breaks building in FC25.

Otherwise rpmbuild generates various debugfiles.list files and then complains that they are empty.  Adding that global disables it.